### PR TITLE
+= Operator

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -15,7 +15,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(\w|[-_])+\s*\??=</string>
+			<string>^(\w|[-_])+\s*[\?\+]?=</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>


### PR DESCRIPTION
Added `+=` operator to source highlighting.

e.g.:

```
  var1  = 1;
  var2 ?= 2;
  var3 += 3;
```
