### PR TITLE
Highlighting for := assignment operator

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -15,7 +15,7 @@
 	<array>
 		<dict>
 			<key>begin</key>
-			<string>^(\w|[-_])+\s*[\?\+]?=</string>
+			<string>^(\w|[-_])+\s*[:\?\+]?=</string>
 			<key>end</key>
 			<string>$</string>
 			<key>name</key>


### PR DESCRIPTION
The current bundle does not highlight variable assignments using the `:=` operator. This commit fixes that.
