### PR TITLE
SMCS Compiler output

### DIFF
--- a/Support/lib/make.rb
+++ b/Support/lib/make.rb
@@ -36,6 +36,9 @@ def perform_make(target = nil)
     elsif line =~ /^g?make.*?: Leaving directory `(.*?)'$/ and not $1.nil? and File.directory?($1)
       dirs.delete($1)
       ""
+    elsif line =~ /^\s*(.*?)\((\d+),(\d+)\):\s*((?:warning|error)\s+.*)$/ and not $1.nil?
+      # smcs (C#)
+      make_txmt_link(dirs, $1, $2, $3, $4)
     elsif line =~ /^(.*?):(?:(\d+):)?(?:(\d+):)?\s*(.*?)$/ and not $1.nil?
       # GCC, et al
       make_txmt_link(dirs, $1, $2, $3, $4)


### PR DESCRIPTION
This adds support for creating links from the SMCS C# compiler (used by the Mono framework).
I'm not sure if you want to pull this, but the regex shouldn't clash with standard GCC/LLVM output.

The output from SMCS is of the form:

```
/path/to/file.cs(696,49): warning CS0436: Actual warning message.
```

I verified with an iOS project that the existing linkification did not break.
