### PR TITLE
Fix origin and flavor tokenization

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -682,7 +682,7 @@
 							<key>contentName</key>
 							<string>variable.other.makefile</string>
 							<key>end</key>
-							<string>\)</string>
+							<string>(?=\))</string>
 							<key>name</key>
 							<string>meta.scope.function-call.makefile</string>
 							<key>patterns</key>


### PR DESCRIPTION
Fixes the issue reported by @philtay in #9: [demo in Lightshow](https://github-lightshow.herokuapp.com/?utf8=%E2%9C%93&scope=from-url&grammar_url=https%3A%2F%2Fraw.githubusercontent.com%2Fpchaigno%2Fmake.tmbundle%2Ffix-9%2FSyntaxes%2FMakefile.plist&grammar_text=&code_source=from-text&code_url=&code=define+foobar%0D%0A%24%28and+%24%28filter-out+undefined%2C%24%28origin+1%29%29%2C%24%281%29%29%0D%0Aendef%0D%0A%0D%0Adefine+test%0D%0Acommand%0D%0Aendef).