### PR TITLE
Fix `else` followed by no space is not highlighted 

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -368,7 +368,7 @@
 						</dict>
 						<dict>
 							<key>begin</key>
-							<string>^else(?=\s)</string>
+							<string>^else(?=\s|$)</string>
 							<key>beginCaptures</key>
 							<dict>
 								<key>0</key>


### PR DESCRIPTION
On GitHub I noticed `else` followed by no space was not highlighted as follows:

<img width="484" alt="スクリーンショット 2021-08-01 16 25 59" src="https://user-images.githubusercontent.com/823277/127762975-95133a4c-1905-46c1-becf-0c5545167fda.png">

https://github.com/rhysd/actionlint/blob/7537431efdd2f612b451cd2e0d72a204f8f82acb/Makefile#L20

This PR fixes the issue.